### PR TITLE
Delphi XE 1 compatibility

### DIFF
--- a/src/PropertiesFile4D.inc
+++ b/src/PropertiesFile4D.inc
@@ -1,0 +1,8 @@
+{$IF System.CompilerVersion > 22.0}
+  {$DEFINE CompilerVersion_DelphiXE_greater}
+{$IFEND}
+
+{$IFDEF CompilerVersion_DelphiXE_greater}
+  {$DEFINE USE_SYSTEM_NAMESPACE}
+  {$DEFINE USE_STRING_CLASS}
+{$ENDIF CompilerVersion_DelphiXE_greater}

--- a/src/PropertiesFile4D.pas
+++ b/src/PropertiesFile4D.pas
@@ -1,11 +1,20 @@
 unit PropertiesFile4D;
 
+{$INCLUDE PropertiesFile4D.inc}
+
 interface
 
+{$IFDEF USE_SYSTEM_NAMESPACE}
 uses
   System.Classes,
   System.SysUtils,
   System.StrUtils;
+{$ELSE USE_SYSTEM_NAMESPACE}
+uses
+  Classes,
+  SysUtils,
+  StrUtils;
+{$ENDIF USE_SYSTEM_NAMESPACE}
 
 type
 

--- a/unittest/PropertiesFile4D.UnitTest.Mapping.pas
+++ b/unittest/PropertiesFile4D.UnitTest.Mapping.pas
@@ -2,10 +2,17 @@ unit PropertiesFile4D.UnitTest.Mapping;
 
 interface
 
+{$INCLUDE ..\src\PropertiesFile4D.inc}
+
 uses
   TestFramework,
+  {$IFDEF USE_SYSTEM_NAMESPACE}
   System.Classes,
   System.SysUtils,
+  {$ELSE USE_SYSTEM_NAMESPACE}
+  Classes,
+  SysUtils,
+  {$ENDIF USE_SYSTEM_NAMESPACE}
   PropertiesFile4D.Mapping,
   PropertiesFile4D;
 

--- a/unittest/PropertiesFile4D.UnitTest.pas
+++ b/unittest/PropertiesFile4D.UnitTest.pas
@@ -2,10 +2,17 @@ unit PropertiesFile4D.UnitTest;
 
 interface
 
+{$INCLUDE ..\src\PropertiesFile4D.inc}
+
 uses
   TestFramework,
+  {$IFDEF USE_SYSTEM_NAMESPACE}
   System.Classes,
   System.SysUtils,
+  {$ELSE USE_SYSTEM_NAMESPACE}
+  Classes,
+  SysUtils,
+  {$ENDIF USE_SYSTEM_NAMESPACE}
   PropertiesFile4D;
 
 type


### PR DESCRIPTION
PropertiesFile4Delphi is now compatible with _Delphi XE 1_ :
- System namespace was unknown
- String wasn't a class and so IsEmpty and Equals methods don't exist
